### PR TITLE
Correção em datas das políticas de validação da assinatura.

### DIFF
--- a/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_1_0.java
+++ b/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_1_0.java
@@ -240,7 +240,7 @@ public class ADRBCMS_1_0 implements SignaturePolicy {
 		// Para a versão 1.0, o período para assinatura desta PA é de 31/10/2008
 		// a 31/12/2014
 		Calendar calendar = GregorianCalendar.getInstance();
-		calendar.set(2008, Calendar.OCTOBER, 30, 0, 0, 0);
+		calendar.set(2008, Calendar.OCTOBER, 31, 0, 0, 0);
 		Date firstDate = calendar.getTime();
 
 		calendar.set(2014, Calendar.DECEMBER, 31, 23, 59, 59);

--- a/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_1_1.java
+++ b/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_1_1.java
@@ -239,12 +239,12 @@ public class ADRBCMS_1_1 implements SignaturePolicy {
 		}
 
 		// Para a versão 1.1, o período para assinatura desta PA é de 26/12/2011
-		// a 31/12/2014.
+		// a 29/02/2012.
 		Calendar calendar = GregorianCalendar.getInstance();
-		calendar.set(2011, Calendar.DECEMBER, 25, 0, 0, 0);
+		calendar.set(2011, Calendar.DECEMBER, 26, 0, 0, 0);
 		Date firstDate = calendar.getTime();
 
-		calendar.set(2014, Calendar.DECEMBER, 31, 23, 59, 59);
+		calendar.set(2012, Calendar.FEBRUARY, 29, 23, 59, 59);
 		Date lastDate = calendar.getTime();
 
 		if (dataSigner != null) {
@@ -252,7 +252,7 @@ public class ADRBCMS_1_1 implements SignaturePolicy {
 				throw new SignerException("Invalid signing time. Not valid before 12/26/2011");
 			}
 			if (dataSigner.after(lastDate)) {
-				throw new SignerException("Invalid signing time. Not valid after 12/31/2014");
+				throw new SignerException("Invalid signing time. Not valid after 02/29/2012");
 			}
 		} else {
 			throw new SignerException("There is SigningTime attribute on Package PKCS7, but it is null");

--- a/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_2_1.java
+++ b/impl/signer/src/main/java/br/gov/frameworkdemoiselle/certificate/signer/pkcs7/bc/policies/ADRBCMS_2_1.java
@@ -246,10 +246,10 @@ public class ADRBCMS_2_1 implements SignaturePolicy {
 
 		if (dataSigner != null) {
 			if (dataSigner.before(firstDate)) {
-				throw new SignerException("Invalid signing time. Not valid before march/06/2011");
+				throw new SignerException("Invalid signing time. Not valid before 03/06/2011");
 			}
 			if (dataSigner.after(lastDate)) {
-				throw new SignerException("Invalid signing time. Not valid after june/21/2023");
+				throw new SignerException("Invalid signing time. Not valid after 06/21/2023");
 			}
 		} else {
 			throw new SignerException("There is SigningTime attribute on Package PKCS7, but it is null");


### PR DESCRIPTION
Identifiquei que a data de validade das políticas de validação da assinatura AD-RB CMS 1.0 e 1.1 estavam incorretas.
Fonte: http://www.iti.gov.br/images/twiki/URL/pub/Certificacao/DocIcp/docs13082012/DOC-ICP-15.03_-_Versao_6.1.pdf página 32.
