### PR TITLE
Inclusão do Driver do Leitor de SmartCard Gemalto Gem PC TR USB

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/certificate/keystore/loader/configuration/Configuration.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/certificate/keystore/loader/configuration/Configuration.java
@@ -121,7 +121,6 @@ public class Configuration {
         //Leitor Gemalto Mac
         map.put("TokenOuSmartCard_38", "/usr/local/lib/libaetpkss.dylib");
 
-
         for (String driver : map.keySet()) {
             try {
                 this.addDriver(driver, map.get(driver));


### PR DESCRIPTION
Prezados,

Foi incluído no mapeamento de drivers padrão, o driver fornecido pela certisign para MacOs.
