### PR TITLE
Remoção do nível de compressão.

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/certificate/util/ZipBytes.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/certificate/util/ZipBytes.java
@@ -27,7 +27,6 @@ public final class ZipBytes {
                 LOGGER.log(Level.INFO, "Adding file {0} to ZIP", fileName);
                 zipOut.putNextEntry(new ZipEntry(fileName));
                 zipOut.write(files.get(fileName));
-                zipOut.setLevel(0);
                 zipOut.closeEntry();
             }
             zipOut.close();


### PR DESCRIPTION
A definição do nível de compressão está gerando um arquivo Zip corrompido, quando executado no Java 8 Update 151. Ao remove-lo, o Zip é gerado corretamente em todas as versões.